### PR TITLE
Fix database filename not updated during file organization (Issue #11)

### DIFF
--- a/xisf_catalog.py
+++ b/xisf_catalog.py
@@ -915,8 +915,10 @@ class XISFCatalogGUI(QMainWindow):
                         shutil.copy2(filepath, new_path)
                         self.organize_log.append(f"✓ Copied: {os.path.basename(new_path)}")
                     
-                    # Update database with new path
-                    cursor.execute('UPDATE xisf_files SET filepath = ? WHERE id = ?', (new_path, file_id))
+                    # Update database with new path and filename
+                    new_filename = os.path.basename(new_path)
+                    cursor.execute('UPDATE xisf_files SET filepath = ?, filename = ? WHERE id = ?',
+                                   (new_path, new_filename, file_id))
                     success_count += 1
                     
                 except Exception as e:


### PR DESCRIPTION
- Updated execute_organization() to update both filepath AND filename fields
- Extracts new filename from new_path using os.path.basename()
- Ensures database stays consistent with actual file on disk

Before: Only filepath was updated, leaving old filename in database
After: Both filepath and filename are updated correctly

Example:
Before fix:
  - filepath: /repo/Lights/M31/Ha/2024-10-15_M31_Ha_300s_-10C_Bin1x1_001.xisf ✓
  - filename: IMG_001.xisf ✗ (wrong - not updated)

After fix:
  - filepath: /repo/Lights/M31/Ha/2024-10-15_M31_Ha_300s_-10C_Bin1x1_001.xisf ✓
  - filename: 2024-10-15_M31_Ha_300s_-10C_Bin1x1_001.xisf ✓ (correct)

Fixes #11