### PR TITLE
Add column width persistence for Sessions tab

### DIFF
--- a/xisf_catalog.py
+++ b/xisf_catalog.py
@@ -1518,6 +1518,7 @@ class XISFCatalogGUI(QMainWindow):
         """Connect signals after all widgets are created"""
         # Connect column resize signals to save settings
         self.catalog_tree.header().sectionResized.connect(self.save_settings)
+        self.sessions_tree.header().sectionResized.connect(self.save_settings)
     
     def save_settings(self):
         """Save window size and column widths"""
@@ -1527,6 +1528,10 @@ class XISFCatalogGUI(QMainWindow):
         # Save catalog tree column widths
         for i in range(self.catalog_tree.columnCount()):
             self.settings.setValue(f'catalog_tree_col_{i}', self.catalog_tree.columnWidth(i))
+
+        # Save sessions tree column widths
+        for i in range(self.sessions_tree.columnCount()):
+            self.settings.setValue(f'sessions_tree_col_{i}', self.sessions_tree.columnWidth(i))
     
     def restore_settings(self):
         """Restore window size and column widths"""
@@ -1540,6 +1545,12 @@ class XISFCatalogGUI(QMainWindow):
             width = self.settings.value(f'catalog_tree_col_{i}')
             if width is not None:
                 self.catalog_tree.setColumnWidth(i, int(width))
+
+        # Restore sessions tree column widths
+        for i in range(self.sessions_tree.columnCount()):
+            width = self.settings.value(f'sessions_tree_col_{i}')
+            if width is not None:
+                self.sessions_tree.setColumnWidth(i, int(width))
 
         # Connect signals after restoring settings to avoid triggering saves during restore
         self.connect_signals()


### PR DESCRIPTION
Column widths in the Sessions tab were not being saved when switching between tabs. This implements the same persistence mechanism used by the View Catalog tab.

Changes:
- Added sessions_tree.header().sectionResized signal connection
- Save sessions_tree column widths in save_settings()
- Restore sessions_tree column widths in restore_settings()

Column widths now persist across tab switches and application restarts.