### PR TITLE
Remove auto-resize that overrides user column width preferences

### DIFF
--- a/xisf_catalog.py
+++ b/xisf_catalog.py
@@ -2132,10 +2132,6 @@ class XISFCatalogGUI(QMainWindow):
             # Update statistics panel
             self.update_session_statistics(total_count, complete_count, partial_count, missing_count)
 
-            # Resize columns
-            for i in range(6):
-                self.sessions_tree.resizeColumnToContents(i)
-
         except Exception as e:
             QMessageBox.critical(self, 'Error', f'Failed to refresh sessions: {e}')
 


### PR DESCRIPTION
Issue #33: Column widths were being reset every time the Sessions tab refreshed because resizeColumnToContents() was being called after loading data, overriding the user's saved column width preferences.

Changes:
- Removed resizeColumnToContents() loop from refresh_sessions()
- Column widths now use defaults set in create_sessions_tab()
- User-adjusted widths are properly saved and restored via QSettings
- Widths persist across tab switches and application restarts

Default column widths (set in create_sessions_tab):
- Session: 250px
- Status: 100px
- Light Frames: 120px
- Darks: 150px
- Bias: 150px
- Flats: 150px

Fixes #33