### PR TITLE
Rename application to AstroFileManager

### DIFF
--- a/AstroFileManager.py
+++ b/AstroFileManager.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-PyQt GUI for XISF Catalog Database
+AstroFileManager - XISF File Management for Astrophotography
+A PyQt6-based application for cataloging, organizing, and managing XISF astrophotography files.
 """
 
 import sys
@@ -377,14 +378,14 @@ class XISFCatalogGUI(QMainWindow):
     def __init__(self):
         super().__init__()
         self.db_path = 'xisf_catalog.db'
-        self.settings = QSettings('XISFCatalog', 'CatalogGUI')
+        self.settings = QSettings('AstroFileManager', 'AstroFileManager')
         self.init_ui()
         # Restore settings after all UI is created
         self.restore_settings()
     
     def init_ui(self):
         """Initialize the user interface"""
-        self.setWindowTitle('XISF Catalog Manager')
+        self.setWindowTitle('AstroFileManager')
         self.setGeometry(100, 100, 1000, 600)
         
         # Create central widget and main layout
@@ -2591,7 +2592,7 @@ def main():
     app = QApplication(sys.argv)
     
     # Load theme setting
-    settings = QSettings('XISFCatalog', 'CatalogGUI')
+    settings = QSettings('AstroFileManager', 'AstroFileManager')
     theme = settings.value('theme', 'dark')
     
     # Apply theme

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# XISF Catalog Manager
+# AstroFileManager
 
 A PyQt6-based desktop application for cataloging and managing XISF astrophotography files. This application reads FITS header information from XISF files and stores them in a SQLite database for easy browsing and analysis.
 
@@ -92,7 +92,7 @@ pip install PyQt6 xisf
 2. Create the database using the database creation script:
 
 ```bash
-python create_database.py
+python create_db.py
 ```
 
 This creates `xisf_catalog.db` in the current directory.
@@ -100,7 +100,7 @@ This creates `xisf_catalog.db` in the current directory.
 3. Run the GUI application:
 
 ```bash
-python xisf_catalog_gui.py
+python AstroFileManager.py
 ```
 
 ## Usage
@@ -551,7 +551,7 @@ Settings are stored using Qt's QSettings in platform-specific locations and are 
 ## Troubleshooting
 
 **"Database not found" error:**
-- Make sure you've created the database using `create_database.py` first
+- Make sure you've created the database using `create_db.py` first
 - The database file `xisf_catalog.db` must be in the same directory as the GUI script
 
 **Date fields showing NULL:**
@@ -593,11 +593,11 @@ Settings are stored using Qt's QSettings in platform-specific locations and are 
 ## File Structure
 
 ```
-xisf-catalog/
-├── create_database.py      # Database creation script
-├── xisf_catalog_gui.py     # Main GUI application
+AstroFileManager/
+├── create_db.py            # Database creation script
+├── AstroFileManager.py     # Main GUI application
 ├── xisf_catalog.db         # SQLite database (created on first run)
-└── README.md               # This file
+└── readme.md               # This file
 ```
 
 ## License


### PR DESCRIPTION
Renamed application from "XISF Catalog Manager" to "AstroFileManager" for a more concise and descriptive name.

Changes:
- Renamed xisf_catalog.py to AstroFileManager.py (preserving git history)
- Updated window title from 'XISF Catalog Manager' to 'AstroFileManager'
- Updated QSettings organization/application name from 'XISFCatalog'/'CatalogGUI' to 'AstroFileManager'/'AstroFileManager'
- Updated file docstring with better description
- Updated README.md:
  - Changed title from "XISF Catalog Manager" to "AstroFileManager"
  - Updated all script references (xisf_catalog_gui.py -> AstroFileManager.py)
  - Updated file structure section with correct filenames
  - Updated database creation command (create_database.py -> create_db.py)
  - Updated folder structure diagram to reflect new name

Note: Database filename (xisf_catalog.db) intentionally kept unchanged to maintain compatibility with existing installations.

All functionality remains identical - this is purely a cosmetic rename to improve application branding and consistency.