### PR TITLE
Fix Issue #44: View Catalog tab blank at startup

### DIFF
--- a/AstroFileManager.py
+++ b/AstroFileManager.py
@@ -383,7 +383,9 @@ class XISFCatalogGUI(QMainWindow):
         self.init_ui()
         # Restore settings after all UI is created
         self.restore_settings()
-    
+        # Populate the View Catalog tab on startup (fixes Issue #44)
+        self.refresh_catalog_view()
+
     def init_ui(self):
         """Initialize the user interface"""
         self.setWindowTitle('AstroFileManager')


### PR DESCRIPTION
The View Catalog tab was displaying blank content when the application first loaded, requiring users to switch to another tab and back to see the catalog data.

Root cause: refresh_catalog_view() was never called during initialization. Since View Catalog is the default tab (index 0), the on_tab_changed event doesn't fire at startup.

Solution: Added refresh_catalog_view() call after UI initialization and settings restoration in __init__. This ensures the catalog is populated immediately when the application starts.

Closes #44