### PR TITLE
Fix Issue #43: Temperature grouping too narrow in View Catalog tab

### DIFF
--- a/AstroFileManager.py
+++ b/AstroFileManager.py
@@ -2396,14 +2396,14 @@ Imported: {result[11] or 'N/A'}
             cursor.execute('''
                 SELECT
                     exposure,
-                    ROUND(ccd_temp) as ccd_temp,
+                    ROUND(ccd_temp / 2.0) * 2 as ccd_temp,
                     xbinning,
                     ybinning,
                     COUNT(*) as file_count
                 FROM xisf_files
                 WHERE imagetyp LIKE '%Dark%' AND object IS NULL
-                GROUP BY exposure, ROUND(ccd_temp), xbinning, ybinning
-                ORDER BY exposure, ROUND(ccd_temp), xbinning, ybinning
+                GROUP BY exposure, ROUND(ccd_temp / 2.0) * 2, xbinning, ybinning
+                ORDER BY exposure, ROUND(ccd_temp / 2.0) * 2, xbinning, ybinning
             ''')
 
             dark_groups = cursor.fetchall()
@@ -2499,7 +2499,7 @@ Imported: {result[11] or 'N/A'}
                 cursor.execute('''
                     SELECT
                         filter,
-                        ROUND(ccd_temp) as ccd_temp,
+                        ROUND(ccd_temp / 2.0) * 2 as ccd_temp,
                         xbinning,
                         ybinning,
                         COUNT(*) as file_count
@@ -2507,8 +2507,8 @@ Imported: {result[11] or 'N/A'}
                     WHERE imagetyp LIKE '%Flat%'
                         AND object IS NULL
                         AND (date_loc = ? OR (date_loc IS NULL AND ? IS NULL))
-                    GROUP BY filter, ROUND(ccd_temp), xbinning, ybinning
-                    ORDER BY filter, ROUND(ccd_temp), xbinning, ybinning
+                    GROUP BY filter, ROUND(ccd_temp / 2.0) * 2, xbinning, ybinning
+                    ORDER BY filter, ROUND(ccd_temp / 2.0) * 2, xbinning, ybinning
                 ''', (date_val, date_val))
 
                 flat_groups = cursor.fetchall()
@@ -2570,14 +2570,14 @@ Imported: {result[11] or 'N/A'}
 
             cursor.execute('''
                 SELECT
-                    ROUND(ccd_temp) as ccd_temp,
+                    ROUND(ccd_temp / 2.0) * 2 as ccd_temp,
                     xbinning,
                     ybinning,
                     COUNT(*) as file_count
                 FROM xisf_files
                 WHERE imagetyp LIKE '%Bias%' AND object IS NULL
-                GROUP BY ROUND(ccd_temp), xbinning, ybinning
-                ORDER BY ROUND(ccd_temp), xbinning, ybinning
+                GROUP BY ROUND(ccd_temp / 2.0) * 2, xbinning, ybinning
+                ORDER BY ROUND(ccd_temp / 2.0) * 2, xbinning, ybinning
             ''')
 
             bias_groups = cursor.fetchall()


### PR DESCRIPTION
The View Catalog tab was creating separate groups for every integer degree of temperature (±0.5°C effective tolerance), leading to excessive frame fragmentation. For example, frames at -10.4°C and -9.6°C would appear in separate groups despite being within calibration matching tolerance.

Problem:
- Current grouping: ROUND(ccd_temp) creates groups at exact integers
- Effective tolerance: ±0.5°C
- Result: Too many small groups that are actually interchangeable
- Inconsistency: Sessions tab uses ±1°C tolerance for matching

Solution:
Changed temperature rounding from ROUND(ccd_temp) to ROUND(ccd_temp / 2.0) * 2 in three SQL queries:
- Dark frames grouping (lines 2399, 2405, 2406)
- Flat frames grouping (lines 2502, 2510, 2511)
- Bias frames grouping (lines 2573, 2579, 2580)

Benefits:
- Creates 2-degree-wide buckets (±1°C effective tolerance)
- Aligns with calibration matching logic in Sessions tab
- Reduces fragmentation while maintaining appropriate precision
- Example: -11°C, -10°C, -9°C frames now group as "-10°C"

Closes #43