### PR TITLE
Fix: Remove imports for non-existent tab modules

### DIFF
--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -6,17 +6,14 @@ Each tab is implemented as a separate class to improve modularity.
 """
 
 from .import_tab import ImportTab
-from .view_tab import ViewTab
-from .sessions_tab import SessionsTab
-from .analytics_tab import AnalyticsTab
-from .maintenance_tab import MaintenanceTab
-from .settings_tab import SettingsTab
 
 __all__ = [
-    'ImportTab',
-    'ViewTab',
-    'SessionsTab',
-    'AnalyticsTab',
-    'MaintenanceTab',
-    'SettingsTab'
+    'ImportTab'
 ]
+
+# Future tab classes will be added here:
+# from .view_tab import ViewTab
+# from .sessions_tab import SessionsTab
+# from .analytics_tab import AnalyticsTab
+# from .maintenance_tab import MaintenanceTab
+# from .settings_tab import SettingsTab


### PR DESCRIPTION
Only import ImportTab which exists, comment out future tab imports. This fixes ModuleNotFoundError when importing the ui package.