### PR TITLE
Fix: Update on_tab_changed to access maintenance_tab attributes

### DIFF
--- a/AstroFileManager.py
+++ b/AstroFileManager.py
@@ -2122,8 +2122,8 @@ Imported: {result[11] or 'N/A'}
             self.refresh_analytics()
         elif index == 4:  # Maintenance tab
             # Populate current values when maintenance tab is opened
-            keyword = self.keyword_combo.currentText()
-            self.populate_current_values(keyword)
+            keyword = self.maintenance_tab.keyword_combo.currentText()
+            self.maintenance_tab.populate_current_values(keyword)
 
     def refresh_sessions(self):
         """Refresh the sessions view"""


### PR DESCRIPTION
The keyword_combo and populate_current_values are now in the MaintenanceTab class, so we need to access them through self.maintenance_tab instead of self.

Fixes AttributeError when switching to Maintenance tab.