### PR TITLE
Fix Issue #42: Master frames now show 100% quality

### DIFF
--- a/core/calibration.py
+++ b/core/calibration.py
@@ -104,7 +104,11 @@ class CalibrationMatcher:
                 master_count = cursor.fetchone()[0] or 0
 
             # Calculate quality score (0-100)
-            quality = min(100, (dark_count / self.min_frames_recommended) * 100) if dark_count > 0 else 0
+            # If master frame is present, quality is 100%
+            if master_count > 0:
+                quality = 100
+            else:
+                quality = min(100, (dark_count / self.min_frames_recommended) * 100) if dark_count > 0 else 0
 
             # Determine display text and status
             if master_count > 0:
@@ -179,7 +183,11 @@ class CalibrationMatcher:
                 master_count = cursor.fetchone()[0] or 0
 
             # Calculate quality score (0-100)
-            quality = min(100, (bias_count / self.min_frames_recommended) * 100) if bias_count > 0 else 0
+            # If master frame is present, quality is 100%
+            if master_count > 0:
+                quality = 100
+            else:
+                quality = min(100, (bias_count / self.min_frames_recommended) * 100) if bias_count > 0 else 0
 
             # Determine display text and status
             if master_count > 0:
@@ -260,7 +268,11 @@ class CalibrationMatcher:
                 master_count = cursor.fetchone()[0] or 0
 
             # Calculate quality score (0-100)
-            quality = min(100, (flat_count / self.min_frames_recommended) * 100) if flat_count > 0 else 0
+            # If master frame is present, quality is 100%
+            if master_count > 0:
+                quality = 100
+            else:
+                quality = min(100, (flat_count / self.min_frames_recommended) * 100) if flat_count > 0 else 0
 
             # Determine display text and status
             if master_count > 0:


### PR DESCRIPTION
Modified quality calculation to return 100% when master calibration frames are present, regardless of individual frame count.

**Changes:**
- Updated find_matching_darks() to set quality=100 when master_count > 0
- Updated find_matching_bias() to set quality=100 when master_count > 0
- Updated find_matching_flats() to set quality=100 when master_count > 0

**Rationale:**
Master frames are already high-quality calibration products created from stacking many individual frames. They represent optimal calibration quality and should be scored as 100% rather than being limited by the individual frame count in the same session.

**Behavior:**
Before:
- Session with 5 individual darks + 1 master dark: 25% quality
- Quality only counted individual frames, ignored master presence

After:
- Session with any individual frames + 1 master frame: 100% quality
- Recognizes that master frames provide complete calibration

**Example:**
- 5 darks + 1 master dark: 100% quality (was 25%)
- 0 darks + 1 master dark: 100% quality (was 0%)
- 15 darks + 0 masters: 75% quality (unchanged)

Closes #42