### PR TITLE
Fix Issue #66: Simplify complete session colors to green

### DIFF
--- a/core/calibration.py
+++ b/core/calibration.py
@@ -315,16 +315,8 @@ class CalibrationMatcher:
         has_bias = bias_info['has_frames']
         has_flats = flats_info['has_frames']
 
-        # Check if we have master frames
-        has_master = (darks_info['master_count'] > 0 or
-                     bias_info['master_count'] > 0 or
-                     flats_info['master_count'] > 0)
-
         if has_darks and has_bias and has_flats:
-            if has_master:
-                return 'Complete', QColor(0, 150, 255)  # Blue for complete with masters
-            else:
-                return 'Complete', QColor(0, 200, 0)  # Green for complete
+            return 'Complete', QColor(0, 200, 0)  # Green for complete
         elif not has_darks and not has_bias and not has_flats:
             return 'Missing', QColor(200, 0, 0)  # Red for missing all
         else:


### PR DESCRIPTION
Removed separate color for sessions with master frames. All complete sessions now display in green regardless of master frame presence.

**Changes:**
- Removed has_master check from calculate_session_status()
- All complete sessions now return green (QColor(0, 200, 0))
- Removed blue color for "complete with masters" state

**Color Scheme (Simplified):**
- Complete: Green (all complete sessions, with or without masters)
- Partial: Orange (some calibration missing)
- Missing: Red (no calibration frames)

**Before:**
- Complete with masters: Blue
- Complete without masters: Green
- Partial: Orange
- Missing: Red

**After:**
- Complete: Green (simplified, no distinction for masters)
- Partial: Orange
- Missing: Red

**Rationale:**
Simplifies the UI by reducing color complexity. The presence of master frames is already indicated in the frame counts and quality scores. A separate color was unnecessary visual complexity.

Closes #66