### PR TITLE
Fix Issue #67: Complete sessions now use normal/default colors

### DIFF
--- a/ui/sessions_tab.py
+++ b/ui/sessions_tab.py
@@ -227,9 +227,11 @@ class SessionsTab(QWidget):
                 session_item.setText(4, bias_info['display'])
                 session_item.setText(5, flats_info['display'])
 
-                # Set status color
-                for col in range(6):
-                    session_item.setForeground(col, status_color)
+                # Set status color (only for non-complete sessions)
+                # Complete sessions use default colors
+                if status != 'Complete':
+                    for col in range(6):
+                        session_item.setForeground(col, status_color)
 
                 # Store session data for details view
                 session_item.setData(0, Qt.ItemDataRole.UserRole, {


### PR DESCRIPTION
Modified sessions tab to display complete sessions with default colors instead of green highlighting. Partial and Missing sessions retain their colored display for visibility.

**Changes:**
- Updated sessions_tab.py refresh_sessions() method
- Complete sessions now use default text color (not colored)
- Partial sessions remain orange
- Missing sessions remain red

**Color Scheme:**
Before:
- Complete: Green text
- Partial: Orange text
- Missing: Red text

After:
- Complete: Normal/default text color
- Partial: Orange text (unchanged)
- Missing: Red text (unchanged)

**Rationale:**
Complete sessions don't need special attention, so they use normal colors. Only sessions requiring action (Partial/Missing) are highlighted with colors. This creates a cleaner, less cluttered interface while still drawing attention to sessions that need calibration work.

Closes #67