### PR TITLE
Fix: Correct temperature rounding mismatch in View Catalog grouping

### DIFF
--- a/ui/view_catalog_tab.py
+++ b/ui/view_catalog_tab.py
@@ -734,7 +734,7 @@ Imported: {result[11] or 'N/A'}
                                 WHERE imagetyp LIKE '%Dark%'
                                     AND object IS NULL
                                     AND (exposure = ? OR (exposure IS NULL AND ? IS NULL))
-                                    AND (ROUND(ccd_temp) = ? OR (ccd_temp IS NULL AND ? IS NULL))
+                                    AND (ROUND(ccd_temp / 2.0) * 2 = ? OR (ccd_temp IS NULL AND ? IS NULL))
                                     AND (xbinning = ? OR (xbinning IS NULL AND ? IS NULL))
                                     AND (ybinning = ? OR (ybinning IS NULL AND ? IS NULL))
                                 ORDER BY date_loc DESC
@@ -753,7 +753,7 @@ Imported: {result[11] or 'N/A'}
                                     WHERE imagetyp LIKE '%Dark%'
                                         AND object IS NULL
                                         AND (exposure = ? OR (exposure IS NULL AND ? IS NULL))
-                                        AND (ROUND(ccd_temp) = ? OR (ccd_temp IS NULL AND ? IS NULL))
+                                        AND (ROUND(ccd_temp / 2.0) * 2 = ? OR (ccd_temp IS NULL AND ? IS NULL))
                                         AND (xbinning = ? OR (xbinning IS NULL AND ? IS NULL))
                                         AND (ybinning = ? OR (ybinning IS NULL AND ? IS NULL))
                                         AND (date_loc = ? OR (date_loc IS NULL AND ? IS NULL))
@@ -845,7 +845,7 @@ Imported: {result[11] or 'N/A'}
                                     WHERE {flat_where}
                                         AND (date_loc = ? OR (date_loc IS NULL AND ? IS NULL))
                                         AND (filter = ? OR (filter IS NULL AND ? IS NULL))
-                                        AND (ROUND(ccd_temp) = ? OR (ccd_temp IS NULL AND ? IS NULL))
+                                        AND (ROUND(ccd_temp / 2.0) * 2 = ? OR (ccd_temp IS NULL AND ? IS NULL))
                                         AND (xbinning = ? OR (xbinning IS NULL AND ? IS NULL))
                                         AND (ybinning = ? OR (ybinning IS NULL AND ? IS NULL))
                                     ORDER BY filename
@@ -916,7 +916,7 @@ Imported: {result[11] or 'N/A'}
                                 SELECT DISTINCT date_loc
                                 FROM xisf_files
                                 WHERE {bias_where}
-                                    AND (ROUND(ccd_temp) = ? OR (ccd_temp IS NULL AND ? IS NULL))
+                                    AND (ROUND(ccd_temp / 2.0) * 2 = ? OR (ccd_temp IS NULL AND ? IS NULL))
                                     AND (xbinning = ? OR (xbinning IS NULL AND ? IS NULL))
                                     AND (ybinning = ? OR (ybinning IS NULL AND ? IS NULL))
                                 ORDER BY date_loc DESC
@@ -933,7 +933,7 @@ Imported: {result[11] or 'N/A'}
                                     SELECT filename, imagetyp, exposure, telescop, instrume, date_loc, filter, ccd_temp, xbinning, ybinning
                                     FROM xisf_files
                                     WHERE {bias_where}
-                                        AND (ROUND(ccd_temp) = ? OR (ccd_temp IS NULL AND ? IS NULL))
+                                        AND (ROUND(ccd_temp / 2.0) * 2 = ? OR (ccd_temp IS NULL AND ? IS NULL))
                                         AND (xbinning = ? OR (xbinning IS NULL AND ? IS NULL))
                                         AND (ybinning = ? OR (ybinning IS NULL AND ? IS NULL))
                                         AND (date_loc = ? OR (date_loc IS NULL AND ? IS NULL))


### PR DESCRIPTION
Fixed critical bug where calibration frame groups (darks, flats, bias) could not be expanded due to mismatched temperature rounding logic.

Problem:
- Grouping queries used: ROUND(ccd_temp / 2.0) * 2 (2-degree tolerance)
- File queries used: ROUND(ccd_temp) (1-degree rounding)
- Mismatch caused groups to show "N files" but return 0 files

Example of bug:
- Files at -10.8°C would group as -10°C (ROUND(-10.8/2)*2 = -10)
- But file query looked for ROUND(-10.8) = -11, finding no matches
- Result: Group appears but won't expand

Solution:
Changed all file retrieval queries to use the same 2-degree rounding:
- Dark frames: Lines 737, 756
- Flat frames: Line 848
- Bias frames: Lines 919, 936

Now groups correctly include all files within ±1°C of the rounded temp.

Fixes issue where flats with 2-degree temperature differences couldn't be expanded in the View Catalog tree.