### PR TITLE
Fix: Use last-used directory in file dialogs to prevent data: scheme …

### DIFF
--- a/ui/import_tab.py
+++ b/ui/import_tab.py
@@ -117,18 +117,30 @@ class ImportTab(QWidget):
 
     def import_files(self) -> None:
         """Import individual XISF files."""
+        # Get last used directory, default to home directory
+        last_dir = self.settings.value('last_import_directory', str(Path.home()))
+
         files, _ = QFileDialog.getOpenFileNames(
-            self, 'Select XISF Files', '', 'XISF Files (*.xisf)'
+            self, 'Select XISF Files', last_dir, 'XISF Files (*.xisf)'
         )
 
         if files:
+            # Save the directory of the first selected file for next time
+            selected_dir = str(Path(files[0]).parent)
+            self.settings.setValue('last_import_directory', selected_dir)
             self.start_import(files)
 
     def import_folder(self) -> None:
         """Import all XISF files from a folder and its subfolders."""
-        folder = QFileDialog.getExistingDirectory(self, 'Select Folder')
+        # Get last used directory, default to home directory
+        last_dir = self.settings.value('last_import_directory', str(Path.home()))
+
+        folder = QFileDialog.getExistingDirectory(self, 'Select Folder', last_dir)
 
         if folder:
+            # Save the selected folder for next time
+            self.settings.setValue('last_import_directory', folder)
+
             # Recursively find all .xisf files in folder and subfolders
             files = list(Path(folder).rglob('*.xisf'))
             if files:


### PR DESCRIPTION
…error

The QWindowsNativeFileDialogBase error occurred because file dialogs were using empty string for initial directory, causing Qt to use Windows recent paths which contained "data:" URIs.

Changes:
- Store last used import directory in QSettings
- Default to user's home directory on first use
- Save selected directory after each file/folder selection
- Prevents Qt from trying to process invalid "data:" scheme URIs

Fixes the "Unhandled scheme: data" error on Import XISF Files and Import Folder buttons.