### PR TITLE
Fix: Ensure progress bars remain colored and show data at 100%

### DIFF
--- a/ui/projects_tab.py
+++ b/ui/projects_tab.py
@@ -292,6 +292,15 @@ class ProjectsTab(QWidget):
                 f"({goal.total_count * 100 // goal.target_count if goal.target_count > 0 else 0}%)"
             )
             total_progress.setTextVisible(True)
+            # Style total progress bar with gray/blue color
+            total_progress.setStyleSheet("""
+                QProgressBar {
+                    text-align: center;
+                }
+                QProgressBar::chunk {
+                    background-color: #5bc0de;
+                }
+            """)
             self.goals_layout.addWidget(total_progress)
 
             # Approved progress bar
@@ -307,11 +316,21 @@ class ProjectsTab(QWidget):
             # Color code: green if complete, blue if in progress
             if goal.approved_count >= goal.target_count:
                 approved_progress.setStyleSheet("""
-                    QProgressBar::chunk { background-color: #5cb85c; }
+                    QProgressBar {
+                        text-align: center;
+                    }
+                    QProgressBar::chunk {
+                        background-color: #5cb85c;
+                    }
                 """)
             else:
                 approved_progress.setStyleSheet("""
-                    QProgressBar::chunk { background-color: #5bc0de; }
+                    QProgressBar {
+                        text-align: center;
+                    }
+                    QProgressBar::chunk {
+                        background-color: #5bc0de;
+                    }
                 """)
 
             self.goals_layout.addWidget(approved_progress)


### PR DESCRIPTION
This commit fixes the issue where progress bars in the Projects tab would lose their color and not display frame counts when reaching 100% completion.

Problem:
- When a filter goal reached 100%, the progress bar chunk would not be visible
- The frame count and percentage text would not display properly at 100%
- Only the chunk background color was styled, without proper text alignment

Solution:
- Added comprehensive QProgressBar stylesheet for both total and approved bars
- Ensured text-align: center is set for all progress bars
- Applied consistent styling to QProgressBar::chunk for all states
- Total progress bars now have blue (#5bc0de) color
- Approved progress bars use green (#5cb85c) when complete, blue when in progress
- Text formatting ensures frame count and percentage are always visible

This ensures that completed filter goals are clearly visible with:
- Colored progress bar (green for approved, blue for total)
- Frame count displayed (e.g., "100/100 frames")
- Percentage shown (100%)

File modified:
- ui/projects_tab.py: Updated display_filter_goals() method styling