### PR TITLE
Fix: Give more space to projects list by adjusting splitter proportions

### DIFF
--- a/AstroFileManager.py
+++ b/AstroFileManager.py
@@ -119,6 +119,9 @@ class XISFCatalogGUI(QMainWindow):
 
         # Save sessions tab splitter state
         self.sessions_tab.save_splitter_state()
+
+        # Save projects tab splitter state
+        self.projects_tab.save_splitter_state()
     
     def restore_settings(self) -> None:
         """Restore window size and column widths"""
@@ -141,6 +144,9 @@ class XISFCatalogGUI(QMainWindow):
 
         # Restore sessions tab splitter state
         self.sessions_tab.restore_splitter_state()
+
+        # Restore projects tab splitter state
+        self.projects_tab.restore_splitter_state()
 
         # Connect signals after restoring settings to avoid triggering saves during restore
         self.connect_signals()

--- a/ui/projects_tab.py
+++ b/ui/projects_tab.py
@@ -73,7 +73,7 @@ class ProjectsTab(QWidget):
         layout.addLayout(toolbar)
 
         # Splitter for projects list and details
-        splitter = QSplitter(Qt.Orientation.Vertical)
+        self.projects_splitter = QSplitter(Qt.Orientation.Vertical)
 
         # Projects table
         self.projects_table = QTableWidget()
@@ -91,7 +91,7 @@ class ProjectsTab(QWidget):
             QTableWidget.SelectionMode.SingleSelection
         )
         self.projects_table.itemSelectionChanged.connect(self.on_project_selected)
-        splitter.addWidget(self.projects_table)
+        self.projects_splitter.addWidget(self.projects_table)
 
         # Project details panel
         details_panel = QWidget()
@@ -142,9 +142,16 @@ class ProjectsTab(QWidget):
         details_layout.addLayout(action_buttons)
 
         details_layout.addStretch()
-        splitter.addWidget(details_panel)
+        self.projects_splitter.addWidget(details_panel)
 
-        layout.addWidget(splitter)
+        # Set initial proportions: 70% for projects table, 30% for details
+        # Use 400:200 ratio to give more space to the projects list
+        self.projects_splitter.setSizes([400, 200])
+
+        # Connect splitter movement to save settings
+        self.projects_splitter.splitterMoved.connect(self.save_splitter_state)
+
+        layout.addWidget(self.projects_splitter)
 
     def refresh_projects(self):
         """Refresh the projects list."""
@@ -536,3 +543,16 @@ class ProjectsTab(QWidget):
             QMessageBox.critical(
                 self, "Import Failed", f"Failed to import quality data:\n{str(e)}"
             )
+
+    def save_splitter_state(self) -> None:
+        """Save the splitter sizes to settings."""
+        sizes = self.projects_splitter.sizes()
+        self.settings.setValue('projects_splitter_sizes', sizes)
+
+    def restore_splitter_state(self) -> None:
+        """Restore the splitter sizes from settings."""
+        saved_sizes = self.settings.value('projects_splitter_sizes')
+        if saved_sizes:
+            # Convert to integers (QSettings may return strings)
+            sizes = [int(s) for s in saved_sizes]
+            self.projects_splitter.setSizes(sizes)


### PR DESCRIPTION
This commit improves the Projects tab layout by giving more screen space to the projects list and less to the details panel.

Problem:
- The splitter between projects list and details panel had no initial sizing
- Qt defaults to equal spacing, giving 50% to each panel
- Progress bars and details took up too much space
- Projects list had insufficient room to display projects

Solution:
- Set initial splitter proportions to 400:200 (2:1 ratio)
- Projects table now gets ~67% of the space
- Details panel gets ~33% of the space
- Added save/restore functionality for user-adjusted splitter positions
- User can resize the splitter and position will be remembered across sessions

Implementation:
- Made splitter an instance variable (self.projects_splitter)
- Added setSizes([400, 200]) for initial proportions
- Connected splitter movement to save_splitter_state()
- Added save_splitter_state() and restore_splitter_state() methods
- Updated main app to save/restore projects tab splitter state on close/open

User experience:
- More projects visible in the list without scrolling
- Details panel still fully functional but more compact
- User can drag splitter to preferred position and it's saved
- Consistent with Sessions tab which also has splitter state persistence

Files modified:
- ui/projects_tab.py: Added splitter sizing and save/restore methods
- AstroFileManager.py: Integrated projects tab splitter state management