### PR TITLE
Add capability to unassign sessions from projects

### DIFF
--- a/core/project_manager.py
+++ b/core/project_manager.py
@@ -465,6 +465,101 @@ class ProjectManager:
         finally:
             conn.close()
 
+    def get_session_assignment(
+        self,
+        date_loc: str,
+        object_name: str,
+        filter_name: Optional[str] = None
+    ) -> Optional[Tuple[int, int, str]]:
+        """
+        Check if a session is assigned to a project.
+
+        Args:
+            date_loc: Session date
+            object_name: Object name
+            filter_name: Optional filter name
+
+        Returns:
+            Tuple of (project_id, assignment_id, project_name) if assigned, None otherwise
+        """
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        try:
+            cursor.execute('''
+                SELECT ps.project_id, ps.id, p.name
+                FROM project_sessions ps
+                JOIN projects p ON ps.project_id = p.id
+                WHERE ps.date_loc = ?
+                AND ps.object_name = ?
+                AND (ps.filter = ? OR (ps.filter IS NULL AND ? IS NULL))
+            ''', (date_loc, object_name, filter_name, filter_name))
+
+            result = cursor.fetchone()
+            return result if result else None
+
+        finally:
+            conn.close()
+
+    def unassign_session_from_project(
+        self,
+        date_loc: str,
+        object_name: str,
+        filter_name: Optional[str] = None
+    ):
+        """
+        Unassign a session from a project.
+
+        Args:
+            date_loc: Session date
+            object_name: Object name
+            filter_name: Optional filter name
+        """
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        try:
+            # Get the project_id before deleting
+            cursor.execute('''
+                SELECT project_id
+                FROM project_sessions
+                WHERE date_loc = ?
+                AND object_name = ?
+                AND (filter = ? OR (filter IS NULL AND ? IS NULL))
+            ''', (date_loc, object_name, filter_name, filter_name))
+
+            result = cursor.fetchone()
+            if not result:
+                return  # Session not assigned
+
+            project_id = result[0]
+
+            # Delete the session assignment
+            cursor.execute('''
+                DELETE FROM project_sessions
+                WHERE date_loc = ?
+                AND object_name = ?
+                AND (filter = ? OR (filter IS NULL AND ? IS NULL))
+            ''', (date_loc, object_name, filter_name, filter_name))
+
+            # Unlink frames from project
+            cursor.execute('''
+                UPDATE xisf_files
+                SET project_id = NULL, session_assignment_id = NULL
+                WHERE date_loc = ?
+                AND object = ?
+                AND imagetyp LIKE '%Light%'
+                AND (? IS NULL OR filter = ?)
+            ''', (date_loc, object_name, filter_name, filter_name))
+
+            # Update filter goal counts for the project
+            self._update_filter_goal_counts(cursor, project_id)
+
+            conn.commit()
+
+        finally:
+            conn.close()
+
     def delete_project(self, project_id: int):
         """
         Delete a project and all related data.


### PR DESCRIPTION
Added functionality to unassign sessions from projects in the View Catalog tab:

**ProjectManager (core/project_manager.py):**
- Added get_session_assignment() method to check if a session is currently assigned to a project
- Added unassign_session_from_project() method to unassign a session and update all related data
  - Removes project_sessions entry
  - Clears project_id and session_assignment_id from xisf_files
  - Recalculates filter goal counts for the affected project

**View Catalog Tab (ui/view_catalog_tab.py):**
- Added ProjectManager import and initialization
- Enhanced context menu to dynamically show either:
  - "Assign to Project" for unassigned sessions
  - "Unassign from Project '{project_name}'" for assigned sessions
- Added unassign_session_from_project() method with confirmation dialog
- Displays project name in unassign menu option for clarity

Users can now right-click on a session in the View Catalog tab and:
- See which project it's assigned to (if any)
- Easily unassign it with confirmation
- See updated project progress immediately after unassignment