### PR TITLE
Fix filter matching bug in unassign_session_from_project

### DIFF
--- a/core/project_manager.py
+++ b/core/project_manager.py
@@ -549,7 +549,7 @@ class ProjectManager:
                 WHERE date_loc = ?
                 AND object = ?
                 AND imagetyp LIKE '%Light%'
-                AND (? IS NULL OR filter = ?)
+                AND (filter = ? OR (filter IS NULL AND ? IS NULL))
             ''', (date_loc, object_name, filter_name, filter_name))
 
             # Update filter goal counts for the project


### PR DESCRIPTION
Fixed incorrect filter matching logic when unlinking frames from projects.

**Bug:**
The WHERE clause used `(? IS NULL OR filter = ?)` which incorrectly matched ALL frames when filter_name was NULL, not just frames with NULL filter.

**Fix:**
Changed to `(filter = ? OR (filter IS NULL AND ? IS NULL))` to match the same logic used in the SELECT and DELETE queries for project_sessions.

This ensures only frames from the specific session (matching exact filter or both NULL) are unlinked, and project filter goal counts are correctly updated after unassignment.