### PR TITLE
Fix SNR column import from SubFrame Selector CSV

### DIFF
--- a/import_export/subframe_selector_importer.py
+++ b/import_export/subframe_selector_importer.py
@@ -183,7 +183,7 @@ class SubFrameSelectorImporter:
             'approval_status': approval_status,
             'fwhm': self._parse_float(get_value('FWHM')),
             'eccentricity': self._parse_float(get_value('Eccentricity')),
-            'snr': self._parse_float(get_value('SNRWeight')),
+            'snr': self._parse_float(get_value('SNR') or get_value('SNRWeight')),
             'star_count': self._parse_int(get_value('Stars')),
             'background_level': self._parse_float(get_value('Median')),
             'grading_date': datetime.now().strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
Fixes #121

The SubFrame Selector CSV importer was only checking for 'SNRWeight' column, but some PixInsight versions or configurations export the SNR data with column name 'SNR' instead.

Updated the SNR extraction to check for 'SNR' column first, then fall back to 'SNRWeight' if not found. This maintains backwards compatibility with existing CSV files while supporting both column naming conventions.

Changes:
- Modified _extract_frame_data() to try 'SNR' column first
- Falls back to 'SNRWeight' if 'SNR' column doesn't exist
- Ensures SNR data is properly imported regardless of column name