### PR TITLE
Rename "Export" to "Checkout" in user-facing text

### DIFF
--- a/ui/export_project_dialog.py
+++ b/ui/export_project_dialog.py
@@ -38,7 +38,7 @@ class ExportProjectDialog(QDialog):
         self.worker = None
         self.destination_path = None
 
-        self.setWindowTitle(f"Export Project: {project_name}")
+        self.setWindowTitle(f"Checkout Project: {project_name}")
         self.setMinimumWidth(600)
         self.setMinimumHeight(400)
 
@@ -49,7 +49,7 @@ class ExportProjectDialog(QDialog):
         layout = QVBoxLayout(self)
 
         # Info section
-        info_group = QGroupBox("Export Information")
+        info_group = QGroupBox("Checkout Information")
         info_layout = QVBoxLayout()
 
         info_text = QTextBrowser()
@@ -83,10 +83,10 @@ class ExportProjectDialog(QDialog):
         layout.addWidget(dest_group)
 
         # Progress section
-        progress_group = QGroupBox("Export Progress")
+        progress_group = QGroupBox("Checkout Progress")
         progress_layout = QVBoxLayout()
 
-        self.status_label = QLabel("Ready to export")
+        self.status_label = QLabel("Ready to checkout")
         progress_layout.addWidget(self.status_label)
 
         self.progress_bar = QProgressBar()
@@ -106,7 +106,7 @@ class ExportProjectDialog(QDialog):
         button_layout = QHBoxLayout()
         button_layout.addStretch()
 
-        self.export_btn = QPushButton("Start Export")
+        self.export_btn = QPushButton("Start Checkout")
         self.export_btn.clicked.connect(self.start_export)
         self.export_btn.setEnabled(False)
         button_layout.addWidget(self.export_btn)
@@ -142,7 +142,7 @@ class ExportProjectDialog(QDialog):
         self.browse_btn.setEnabled(False)
         self.close_btn.setEnabled(False)
 
-        self.status_label.setText("Starting export...")
+        self.status_label.setText("Starting checkout...")
         self.progress_bar.setValue(0)
         self.results_label.setText("")
 
@@ -168,7 +168,7 @@ class ExportProjectDialog(QDialog):
     def on_export_finished(self, light_count: int, dark_count: int,
                           flat_count: int, bias_count: int):
         """Handle successful export completion."""
-        self.status_label.setText("Export completed successfully!")
+        self.status_label.setText("Checkout completed successfully!")
         self.progress_bar.setValue(100)
 
         results_html = f"""
@@ -187,14 +187,14 @@ class ExportProjectDialog(QDialog):
 
         QMessageBox.information(
             self,
-            "Export Complete",
-            f"Successfully exported {light_count + dark_count + flat_count + bias_count} files\n\n"
+            "Checkout Complete",
+            f"Successfully checked out {light_count + dark_count + flat_count + bias_count} files\n\n"
             f"Destination: {self.destination_path}"
         )
 
     def on_export_error(self, error_message: str):
         """Handle export error."""
-        self.status_label.setText("Export failed")
+        self.status_label.setText("Checkout failed")
         self.results_label.setText(f"<span style='color: red;'><b>Error:</b> {error_message}</span>")
 
         # Re-enable controls
@@ -202,15 +202,15 @@ class ExportProjectDialog(QDialog):
         self.browse_btn.setEnabled(True)
         self.close_btn.setEnabled(True)
 
-        QMessageBox.critical(self, "Export Failed", error_message)
+        QMessageBox.critical(self, "Checkout Failed", error_message)
 
     def closeEvent(self, event):
         """Handle dialog close event."""
         if self.worker and self.worker.isRunning():
             reply = QMessageBox.question(
                 self,
-                "Export in Progress",
-                "Export is still in progress. Do you want to cancel and close?",
+                "Checkout in Progress",
+                "Checkout is still in progress. Do you want to cancel and close?",
                 QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
                 QMessageBox.StandardButton.No
             )

--- a/ui/export_project_worker.py
+++ b/ui/export_project_worker.py
@@ -77,7 +77,7 @@ class ExportProjectWorker(QThread):
                           len(calib_files['bias']))
 
             if total_files == 0:
-                self.error_occurred.emit("No files to export")
+                self.error_occurred.emit("No files to checkout")
                 return
 
             copied_count = 0
@@ -114,7 +114,7 @@ class ExportProjectWorker(QThread):
                 progress = 15 + int((copied_count / total_files) * 70)
                 self.progress_updated.emit(progress, f"Copying files ({copied_count}/{total_files})...")
 
-            self.progress_updated.emit(100, "Export complete!")
+            self.progress_updated.emit(100, "Checkout complete!")
             self.finished_successfully.emit(
                 len(light_frames),
                 len(calib_files['darks']),
@@ -123,7 +123,7 @@ class ExportProjectWorker(QThread):
             )
 
         except Exception as e:
-            self.error_occurred.emit(f"Export failed: {str(e)}")
+            self.error_occurred.emit(f"Checkout failed: {str(e)}")
 
     def _get_project_light_frames(self) -> List[str]:
         """Get all light frame file paths for the project."""

--- a/ui/projects_tab.py
+++ b/ui/projects_tab.py
@@ -157,7 +157,7 @@ class ProjectsTab(QWidget):
         # Action buttons
         action_buttons = QHBoxLayout()
 
-        self.export_files_btn = QPushButton("Export Files for Processing")
+        self.export_files_btn = QPushButton("Checkout Files for Processing")
         self.export_files_btn.clicked.connect(self.export_project_files)
         self.export_files_btn.setVisible(False)
         action_buttons.addWidget(self.export_files_btn)


### PR DESCRIPTION
Fixes #122

Changed all user-facing text from "Export" to "Checkout" throughout the project file processing feature. This better reflects the operation being performed - checking out files for processing rather than exporting.

Changes:
- Button text: "Export Files for Processing" → "Checkout Files for Processing"
- Dialog title: "Export Project" → "Checkout Project"
- Section headers: "Export Information" → "Checkout Information", "Export Progress" → "Checkout Progress"
- Status messages: All export-related messages now use "checkout"
- Button: "Start Export" → "Start Checkout"
- Message boxes: All titles and messages updated to use "checkout"

Note: Internal code names (functions, classes, files) remain unchanged for backwards compatibility and to minimize code changes.