### PR TITLE
Add feature to identify and remove orphaned calibration frames

### DIFF
--- a/ui/maintenance_tab.py
+++ b/ui/maintenance_tab.py
@@ -217,6 +217,62 @@ class MaintenanceTab(QWidget):
         remove_dupes_group.setLayout(remove_dupes_layout)
         layout.addWidget(remove_dupes_group)
 
+        # Remove Orphaned Calibration Frames section
+        remove_orphans_group = QGroupBox("Remove Orphaned Calibration Frames")
+        remove_orphans_layout = QVBoxLayout()
+
+        remove_orphans_info = QLabel("Identify calibration frames that have no matching light frames:")
+        remove_orphans_layout.addWidget(remove_orphans_info)
+
+        remove_orphans_help = QLabel("Orphaned frames are calibration frames without corresponding light frames in your database.")
+        remove_orphans_help.setStyleSheet("color: #888888; font-size: 10px;")
+        remove_orphans_layout.addWidget(remove_orphans_help)
+
+        # Scan button
+        scan_orphans_btn = QPushButton('Scan for Orphaned Frames')
+        scan_orphans_btn.clicked.connect(self.scan_for_orphaned_frames)
+        remove_orphans_layout.addWidget(scan_orphans_btn)
+
+        # Results display
+        self.orphans_results_label = QLabel("No scan performed yet")
+        self.orphans_results_label.setStyleSheet("padding: 10px; background-color: #f0f0f0; border-radius: 3px;")
+        self.orphans_results_label.setWordWrap(True)
+        remove_orphans_layout.addWidget(self.orphans_results_label)
+
+        # Preview button
+        self.preview_orphans_btn = QPushButton('Preview Orphaned List')
+        self.preview_orphans_btn.clicked.connect(self.preview_orphaned_frames)
+        self.preview_orphans_btn.setEnabled(False)
+        remove_orphans_layout.addWidget(self.preview_orphans_btn)
+
+        # Removal options
+        orphan_options_label = QLabel("Removal action:")
+        remove_orphans_layout.addWidget(orphan_options_label)
+
+        self.orphan_removal_button_group = QButtonGroup()
+
+        self.orphan_remove_db_only_radio = QRadioButton("Remove from database only (keep files on disk)")
+        self.orphan_remove_db_only_radio.setChecked(True)
+        self.orphan_removal_button_group.addButton(self.orphan_remove_db_only_radio)
+        remove_orphans_layout.addWidget(self.orphan_remove_db_only_radio)
+
+        self.orphan_remove_db_and_files_radio = QRadioButton("Remove from database AND delete files from disk")
+        self.orphan_removal_button_group.addButton(self.orphan_remove_db_and_files_radio)
+        remove_orphans_layout.addWidget(self.orphan_remove_db_and_files_radio)
+
+        # Remove button
+        remove_orphans_button_layout = QHBoxLayout()
+        remove_orphans_button_layout.addStretch()
+        self.remove_orphans_btn = QPushButton('Remove Orphaned Frames')
+        self.remove_orphans_btn.clicked.connect(self.remove_orphaned_frames)
+        self.remove_orphans_btn.setEnabled(False)
+        self.remove_orphans_btn.setStyleSheet("QPushButton { background-color: #8b0000; color: white; } QPushButton:hover { background-color: #a00000; }")
+        remove_orphans_button_layout.addWidget(self.remove_orphans_btn)
+        remove_orphans_layout.addLayout(remove_orphans_button_layout)
+
+        remove_orphans_group.setLayout(remove_orphans_layout)
+        layout.addWidget(remove_orphans_group)
+
         # File Organization section
         organize_group = QGroupBox("File Organization")
         organize_layout = QVBoxLayout()
@@ -1103,3 +1159,287 @@ class MaintenanceTab(QWidget):
 
         except Exception as e:
             QMessageBox.critical(self, 'Error', f'Failed to remove duplicates: {e}')
+
+    def scan_for_orphaned_frames(self) -> None:
+        """Scan for orphaned calibration frames with no matching light frames."""
+        try:
+            conn = sqlite3.connect(self.db_path)
+            cursor = conn.cursor()
+
+            # Store orphaned data for later use
+            self.orphaned_data = {
+                'darks': [],
+                'flats': [],
+                'bias': []
+            }
+
+            total_count = 0
+            total_size = 0
+
+            # Find orphaned dark frames (no matching light frames)
+            cursor.execute('''
+                SELECT DISTINCT
+                    i.id, i.filepath, i.filename, i.exposure, i.ccd_temp, i.xbinning, i.ybinning, i.imagetyp
+                FROM xisf_files i
+                WHERE i.imagetyp LIKE '%Dark%'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM xisf_files light
+                      WHERE light.imagetyp LIKE '%Light%'
+                        AND ABS(light.exposure - i.exposure) < 0.1
+                        AND ABS(COALESCE(light.ccd_temp, 0) - COALESCE(i.ccd_temp, 0)) <= 1.0
+                        AND light.xbinning = i.xbinning
+                        AND light.ybinning = i.ybinning
+                  )
+            ''')
+            darks = cursor.fetchall()
+            self.orphaned_data['darks'] = darks
+            total_count += len(darks)
+
+            # Find orphaned flat frames (no matching light frames)
+            cursor.execute('''
+                SELECT DISTINCT
+                    i.id, i.filepath, i.filename, i.filter, i.ccd_temp, i.xbinning, i.ybinning, i.imagetyp
+                FROM xisf_files i
+                WHERE i.imagetyp LIKE '%Flat%'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM xisf_files light
+                      WHERE light.imagetyp LIKE '%Light%'
+                        AND (light.filter = i.filter OR (light.filter IS NULL AND i.filter IS NULL))
+                        AND ABS(COALESCE(light.ccd_temp, 0) - COALESCE(i.ccd_temp, 0)) <= 3.0
+                        AND light.xbinning = i.xbinning
+                        AND light.ybinning = i.ybinning
+                  )
+            ''')
+            flats = cursor.fetchall()
+            self.orphaned_data['flats'] = flats
+            total_count += len(flats)
+
+            # Find orphaned bias frames (no matching light frames)
+            cursor.execute('''
+                SELECT DISTINCT
+                    i.id, i.filepath, i.filename, i.ccd_temp, i.xbinning, i.ybinning, i.imagetyp
+                FROM xisf_files i
+                WHERE i.imagetyp LIKE '%Bias%'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM xisf_files light
+                      WHERE light.imagetyp LIKE '%Light%'
+                        AND ABS(COALESCE(light.ccd_temp, 0) - COALESCE(i.ccd_temp, 0)) <= 1.0
+                        AND light.xbinning = i.xbinning
+                        AND light.ybinning = i.ybinning
+                  )
+            ''')
+            bias = cursor.fetchall()
+            self.orphaned_data['bias'] = bias
+            total_count += len(bias)
+
+            # Calculate total file size
+            for frame_type in ['darks', 'flats', 'bias']:
+                for row in self.orphaned_data[frame_type]:
+                    filepath = row[1]  # filepath is second column
+                    if filepath and os.path.exists(filepath):
+                        total_size += os.path.getsize(filepath)
+
+            conn.close()
+
+            # Format size
+            size_str = self._format_file_size(total_size)
+
+            # Update results label
+            if total_count == 0:
+                self.orphans_results_label.setText(
+                    "No orphaned calibration frames found.\n"
+                    "All calibration frames have corresponding light frames."
+                )
+                self.preview_orphans_btn.setEnabled(False)
+                self.remove_orphans_btn.setEnabled(False)
+            else:
+                results_text = (
+                    f"<b>Found {total_count} orphaned calibration frames:</b><br>"
+                    f"• Dark frames: {len(darks)} files<br>"
+                    f"• Flat frames: {len(flats)} files<br>"
+                    f"• Bias frames: {len(bias)} files<br>"
+                    f"<br><b>Total disk space: {size_str}</b>"
+                )
+                self.orphans_results_label.setText(results_text)
+                self.preview_orphans_btn.setEnabled(True)
+                self.remove_orphans_btn.setEnabled(True)
+
+        except Exception as e:
+            QMessageBox.critical(self, 'Error', f'Failed to scan for orphaned frames: {e}')
+
+    def preview_orphaned_frames(self) -> None:
+        """Show a dialog with the list of orphaned files."""
+        if not hasattr(self, 'orphaned_data'):
+            QMessageBox.warning(self, 'No Data', 'Please scan for orphaned frames first.')
+            return
+
+        # Create dialog
+        dialog = QDialog(self)
+        dialog.setWindowTitle("Orphaned Calibration Frames Preview")
+        dialog.setMinimumWidth(900)
+        dialog.setMinimumHeight(600)
+
+        layout = QVBoxLayout(dialog)
+
+        # Info label
+        total_count = sum(len(self.orphaned_data[t]) for t in ['darks', 'flats', 'bias'])
+        info_label = QLabel(f"The following {total_count} calibration frames have no matching light frames:")
+        layout.addWidget(info_label)
+
+        # Create table
+        table = QTableWidget()
+        table.setColumnCount(5)
+        table.setHorizontalHeaderLabels(['Type', 'Frame Type', 'Filename', 'Parameters', 'Path'])
+        table.horizontalHeader().setStretchLastSection(True)
+        table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+
+        # Populate table
+        row = 0
+        for frame_type, frames in self.orphaned_data.items():
+            for frame in frames:
+                table.insertRow(row)
+
+                # Type
+                type_label = frame_type.capitalize()[:-1]  # Remove trailing 's'
+                table.setItem(row, 0, QTableWidgetItem(type_label))
+
+                # Frame Type (imagetyp from database)
+                if frame_type == 'darks':
+                    imagetyp = frame[7]
+                elif frame_type == 'flats':
+                    imagetyp = frame[7]
+                elif frame_type == 'bias':
+                    imagetyp = frame[6]
+                table.setItem(row, 1, QTableWidgetItem(imagetyp))
+
+                # Filename
+                filename = frame[2]  # filename column
+                table.setItem(row, 2, QTableWidgetItem(filename))
+
+                # Parameters
+                if frame_type == 'darks':
+                    temp_str = f"{frame[4]:.1f}°C" if frame[4] is not None else "N/A"
+                    params = f"Exp:{frame[3]:.1f}s, Temp:{temp_str}, Bin{int(frame[5])}x{int(frame[6])}"
+                elif frame_type == 'flats':
+                    filt = frame[3] or "None"
+                    temp_str = f"{frame[4]:.1f}°C" if frame[4] is not None else "N/A"
+                    params = f"Filter:{filt}, Temp:{temp_str}, Bin{int(frame[5])}x{int(frame[6])}"
+                elif frame_type == 'bias':
+                    temp_str = f"{frame[3]:.1f}°C" if frame[3] is not None else "N/A"
+                    params = f"Temp:{temp_str}, Bin{int(frame[4])}x{int(frame[5])}"
+                table.setItem(row, 3, QTableWidgetItem(params))
+
+                # Path
+                filepath = frame[1]
+                table.setItem(row, 4, QTableWidgetItem(filepath or "N/A"))
+
+                row += 1
+
+        # Resize columns
+        table.resizeColumnsToContents()
+        layout.addWidget(table)
+
+        # Close button
+        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        button_box.rejected.connect(dialog.reject)
+        layout.addWidget(button_box)
+
+        dialog.exec()
+
+    def remove_orphaned_frames(self) -> None:
+        """Remove orphaned calibration frames based on user selection."""
+        if not hasattr(self, 'orphaned_data'):
+            QMessageBox.warning(self, 'No Data', 'Please scan for orphaned frames first.')
+            return
+
+        total_count = sum(len(self.orphaned_data[t]) for t in ['darks', 'flats', 'bias'])
+        if total_count == 0:
+            QMessageBox.information(self, 'No Orphaned Frames', 'No orphaned frames to remove.')
+            return
+
+        # Determine action
+        delete_files = self.orphan_remove_db_and_files_radio.isChecked()
+        action_text = "remove from database AND delete files from disk" if delete_files else "remove from database only"
+
+        # Confirm
+        reply = QMessageBox.question(
+            self, 'Confirm Removal',
+            f'Are you sure you want to {action_text}?\n\n'
+            f'This will affect {total_count} calibration frames.\n\n'
+            f'These frames have no matching light frames in your database.\n\n'
+            f'This action cannot be undone!',
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No
+        )
+
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        try:
+            conn = sqlite3.connect(self.db_path)
+            cursor = conn.cursor()
+
+            removed_count = 0
+            deleted_files_count = 0
+            errors = []
+
+            # Collect all IDs and filepaths
+            all_frames = []
+            for frame_type in ['darks', 'flats', 'bias']:
+                for frame in self.orphaned_data[frame_type]:
+                    file_id = frame[0]
+                    filepath = frame[1]
+                    all_frames.append((file_id, filepath))
+
+            # Remove from database and optionally delete files
+            for file_id, filepath in all_frames:
+                try:
+                    # Remove from database
+                    cursor.execute('DELETE FROM xisf_files WHERE id = ?', (file_id,))
+                    removed_count += 1
+
+                    # Delete file if requested
+                    if delete_files and filepath and os.path.exists(filepath):
+                        os.remove(filepath)
+                        deleted_files_count += 1
+
+                        # Try to clean up empty directories
+                        try:
+                            parent_dir = os.path.dirname(filepath)
+                            if parent_dir and os.path.isdir(parent_dir) and not os.listdir(parent_dir):
+                                os.rmdir(parent_dir)
+                        except:
+                            pass  # Ignore cleanup errors
+
+                except Exception as e:
+                    errors.append(f"File ID {file_id}: {str(e)}")
+
+            conn.commit()
+            conn.close()
+
+            # Show results
+            message = f'Successfully removed {removed_count} orphaned frame(s) from database.'
+            if delete_files:
+                message += f'\n{deleted_files_count} file(s) deleted from disk.'
+
+            if errors:
+                message += f'\n\nErrors encountered:\n' + '\n'.join(errors[:5])
+                if len(errors) > 5:
+                    message += f'\n... and {len(errors) - 5} more'
+                QMessageBox.warning(self, 'Completed with Errors', message)
+            else:
+                QMessageBox.information(self, 'Success', message)
+
+            # Clear orphaned data and reset UI
+            self.orphaned_data = None
+            self.orphans_results_label.setText("No scan performed yet")
+            self.preview_orphans_btn.setEnabled(False)
+            self.remove_orphans_btn.setEnabled(False)
+
+            # Log to import tab if available
+            if self.import_log_widget:
+                self.import_log_widget.append(f'\nRemoved {removed_count} orphaned calibration frames')
+
+        except Exception as e:
+            QMessageBox.critical(self, 'Error', f'Failed to remove orphaned frames: {e}')


### PR DESCRIPTION
Fixes #124

- Added new section in Maintenance tab for orphaned frame management
- Scan for dark, flat, and bias frames with no matching light frames
- Matching criteria: darks (exposure ±0.1s, temp ±1°C), flats (filter, temp ±3°C), bias (temp ±1°C)
- Preview table shows all orphaned frames with parameters and paths
- Option to remove from database only or delete files from disk
- Safety features: preview before removal, explicit confirmation, transaction safety