### PR TITLE
Implement Phase 1: Make quality data visible in UI

### DIFF
--- a/ui/background_workers.py
+++ b/ui/background_workers.py
@@ -18,7 +18,7 @@ class CatalogLoaderWorker(QThread):
     data_ready = pyqtSignal(dict)  # Loaded data
     error_occurred = pyqtSignal(str)  # Error message
 
-    def __init__(self, db_path: str, imagetype_filter: str, object_filter: str):
+    def __init__(self, db_path: str, imagetype_filter: str, object_filter: str, approval_filter: str = 'All'):
         """
         Initialize catalog loader worker.
 
@@ -26,11 +26,13 @@ class CatalogLoaderWorker(QThread):
             db_path: Path to SQLite database
             imagetype_filter: Filter for image type (All, Light, Dark, etc.)
             object_filter: Filter for object name (All or specific object)
+            approval_filter: Filter for approval status (All, Approved, Rejected, Not Graded)
         """
         super().__init__()
         self.db_path = db_path
         self.imagetype_filter = imagetype_filter
         self.object_filter = object_filter
+        self.approval_filter = approval_filter
 
     def run(self):
         """Load catalog data in background thread."""
@@ -72,6 +74,17 @@ class CatalogLoaderWorker(QThread):
                 where_conditions.append('imagetyp LIKE ?')
                 params.append('%Master%')
 
+            # Add approval status filter
+            if self.approval_filter == 'Approved':
+                where_conditions.append('approval_status = ?')
+                params.append('approved')
+            elif self.approval_filter == 'Rejected':
+                where_conditions.append('approval_status = ?')
+                params.append('rejected')
+            elif self.approval_filter == 'Not Graded':
+                where_conditions.append('approval_status = ?')
+                params.append('not_graded')
+
             where_clause = ' AND '.join(where_conditions)
 
             # Load light frames if needed
@@ -80,7 +93,8 @@ class CatalogLoaderWorker(QThread):
                 cursor.execute(f'''
                     SELECT
                         object, filter, date_loc, filename, imagetyp,
-                        exposure, ccd_temp, xbinning, ybinning, telescop, instrume
+                        exposure, ccd_temp, xbinning, ybinning, telescop, instrume,
+                        fwhm, eccentricity, snr, star_count, approval_status
                     FROM xisf_files
                     WHERE {where_clause}
                     ORDER BY object, filter NULLS FIRST, date_loc DESC, filename
@@ -192,7 +206,11 @@ class SessionsLoaderWorker(QThread):
                     COUNT(*) as frame_count,
                     AVG(exposure) as avg_exposure,
                     AVG(ccd_temp) as avg_temp,
-                    xbinning, ybinning
+                    xbinning, ybinning,
+                    AVG(fwhm) as avg_fwhm,
+                    AVG(snr) as avg_snr,
+                    SUM(CASE WHEN approval_status = 'approved' THEN 1 ELSE 0 END) as approved_count,
+                    SUM(CASE WHEN approval_status = 'rejected' THEN 1 ELSE 0 END) as rejected_count
                 FROM xisf_files
                 WHERE imagetyp LIKE '%Light%'
                     AND date_loc IS NOT NULL

--- a/ui/sessions_tab.py
+++ b/ui/sessions_tab.py
@@ -126,16 +126,19 @@ class SessionsTab(QWidget):
 
         # Sessions tree widget
         self.sessions_tree = QTreeWidget()
-        self.sessions_tree.setColumnCount(6)
+        self.sessions_tree.setColumnCount(9)
         self.sessions_tree.setHeaderLabels([
-            'Session', 'Status', 'Light Frames', 'Darks', 'Bias', 'Flats'
+            'Session', 'Status', 'Light Frames', 'FWHM', 'SNR', 'Approved', 'Darks', 'Bias', 'Flats'
         ])
         self.sessions_tree.setColumnWidth(0, 250)
         self.sessions_tree.setColumnWidth(1, 100)
         self.sessions_tree.setColumnWidth(2, 120)
-        self.sessions_tree.setColumnWidth(3, 150)
-        self.sessions_tree.setColumnWidth(4, 150)
-        self.sessions_tree.setColumnWidth(5, 150)
+        self.sessions_tree.setColumnWidth(3, 80)   # FWHM
+        self.sessions_tree.setColumnWidth(4, 80)   # SNR
+        self.sessions_tree.setColumnWidth(5, 100)  # Approved
+        self.sessions_tree.setColumnWidth(6, 150)  # Darks
+        self.sessions_tree.setColumnWidth(7, 150)  # Bias
+        self.sessions_tree.setColumnWidth(8, 150)  # Flats
         self.sessions_tree.itemClicked.connect(self.on_session_clicked)
         layout.addWidget(self.sessions_tree)
 
@@ -250,7 +253,7 @@ class SessionsTab(QWidget):
             missing_count = 0
 
             for session_data in sessions:
-                date, obj, filt, frame_count, avg_exp, avg_temp, xbin, ybin = session_data
+                date, obj, filt, frame_count, avg_exp, avg_temp, xbin, ybin, avg_fwhm, avg_snr, approved_count, rejected_count = session_data
 
                 # Find matching calibration frames from cache (no database queries)
                 darks_info = self.calibration.find_matching_darks_from_cache(
@@ -286,13 +289,20 @@ class SessionsTab(QWidget):
                 session_item.setText(0, session_name)
                 session_item.setText(1, status)
                 session_item.setText(2, f"{frame_count} frames")
-                session_item.setText(3, darks_info['display'])
-                session_item.setText(4, bias_info['display'])
-                session_item.setText(5, flats_info['display'])
+
+                # Quality metrics
+                session_item.setText(3, f"{avg_fwhm:.2f}" if avg_fwhm is not None else 'N/A')
+                session_item.setText(4, f"{avg_snr:.1f}" if avg_snr is not None else 'N/A')
+                session_item.setText(5, f"{approved_count}/{frame_count}" if approved_count else '0/{}'.format(frame_count))
+
+                # Calibration info
+                session_item.setText(6, darks_info['display'])
+                session_item.setText(7, bias_info['display'])
+                session_item.setText(8, flats_info['display'])
 
                 # Set status color (only for non-complete sessions)
                 if status != 'Complete':
-                    for col in range(6):
+                    for col in range(9):
                         session_item.setForeground(col, status_color)
 
                 # Store session data for details view
@@ -305,6 +315,10 @@ class SessionsTab(QWidget):
                     'avg_temp': avg_temp,
                     'xbinning': xbin,
                     'ybinning': ybin,
+                    'avg_fwhm': avg_fwhm,
+                    'avg_snr': avg_snr,
+                    'approved_count': approved_count,
+                    'rejected_count': rejected_count,
                     'darks': darks_info,
                     'bias': bias_info,
                     'flats': flats_info,
@@ -338,6 +352,20 @@ class SessionsTab(QWidget):
 
         details.append(f"<b>Binning:</b> {session_data['xbinning']}x{session_data['ybinning']}<br>")
         details.append(f"<b>Status:</b> {session_data['status']}<br>")
+
+        # Quality metrics
+        details.append("<h4>Quality Metrics:</h4>")
+        avg_fwhm = session_data.get('avg_fwhm')
+        details.append(f"<b>Average FWHM:</b> {avg_fwhm:.2f} arcsec<br>" if avg_fwhm is not None else "<b>Average FWHM:</b> N/A<br>")
+
+        avg_snr = session_data.get('avg_snr')
+        details.append(f"<b>Average SNR:</b> {avg_snr:.1f}<br>" if avg_snr is not None else "<b>Average SNR:</b> N/A<br>")
+
+        approved_count = session_data.get('approved_count', 0)
+        rejected_count = session_data.get('rejected_count', 0)
+        not_graded_count = session_data['frame_count'] - approved_count - rejected_count
+        approval_pct = (approved_count / session_data['frame_count'] * 100) if session_data['frame_count'] > 0 else 0
+        details.append(f"<b>Approval:</b> {approved_count} approved ({approval_pct:.0f}%), {rejected_count} rejected, {not_graded_count} not graded<br>")
 
         details.append("<h4>Calibration Frames:</h4>")
 


### PR DESCRIPTION
Addresses #135

This implements Phase 1 of the processing workflow integration, making quality metrics (imported via SubFrame Selector CSV) visible throughout the UI.

**View Catalog Tab:**
- Added 5 new columns: FWHM, Ecc, SNR, Stars, Status
- Added approval status filter dropdown (All/Approved/Rejected/Not Graded)
- Color-coded rows: green for approved, red for rejected
- Right-click menu actions: Approve Frame, Reject Frame, Clear Grading
- Quality metrics update database and refresh display in real-time

**Sessions Tab:**
- Added 3 new columns: FWHM, SNR, Approved
- Displays average FWHM and SNR per session
- Shows approval count as "X/Y" format
- Session details panel includes quality metrics section
- Shows approval percentage and breakdown

**Background Workers:**
- CatalogLoaderWorker: Added approval_filter parameter
- CatalogLoaderWorker: Fetches quality columns (fwhm, eccentricity, snr, star_count, approval_status)
- SessionsLoaderWorker: Fetches quality aggregates (AVG fwhm/snr, approval counts)
- Approval filter applied in WHERE clause for light frames query

**Key Benefits:**
- Users can now see imported SubFrame Selector quality data
- Filter frames by approval status
- Make approval decisions directly in catalog
- Track session quality at a glance
- Foundation for Phase 2 (integration tools)