### PR TITLE
Fix approval status filtering and right-click actions

### DIFF
--- a/ui/background_workers.py
+++ b/ui/background_workers.py
@@ -82,7 +82,8 @@ class CatalogLoaderWorker(QThread):
                 where_conditions.append('approval_status = ?')
                 params.append('rejected')
             elif self.approval_filter == 'Not Graded':
-                where_conditions.append('approval_status = ?')
+                # Handle both 'not_graded' and NULL (for older records)
+                where_conditions.append('(approval_status = ? OR approval_status IS NULL)')
                 params.append('not_graded')
 
             where_clause = ' AND '.join(where_conditions)

--- a/ui/view_catalog_tab.py
+++ b/ui/view_catalog_tab.py
@@ -257,6 +257,10 @@ class ViewCatalogTab(QWidget):
 
             action = menu.exec(self.catalog_tree.viewport().mapToGlobal(position))
 
+            # Check if user cancelled the menu
+            if action is None:
+                return
+
             # Handle approval actions
             if 'Light' in imagetyp:
                 if action == approve_action:
@@ -1324,6 +1328,10 @@ Imported: {result[11] or 'N/A'}
                     item.setBackground(col, QBrush())
 
             self.status_callback(f"Frame {filename} marked as {status}")
+
+            # If an approval filter is active, refresh the view to apply the filter
+            if hasattr(self, 'catalog_approval_filter') and self.catalog_approval_filter.currentText() != 'All':
+                self.refresh_catalog_view()
 
         except Exception as e:
             QMessageBox.critical(self, 'Error', f'Failed to update approval status: {e}')


### PR DESCRIPTION
Fixed two issues with quality data approval features:

1. Right-click approve/reject actions now work correctly:
   - Added None check to handle menu cancellation
   - Actions properly trigger approve_frame/reject_frame/clear_frame_grading methods

2. Approval status filtering now works correctly:
   - Filter properly applies when selecting Approved/Rejected/Not Graded
   - Handles NULL approval_status values for older records
   - Auto-refreshes view after approval status change when filter is active

Changes:
- ui/view_catalog_tab.py: Added None check for menu action, added refresh after approval status update
- ui/background_workers.py: Updated Not Graded filter to handle NULL values