### PR TITLE
Add quality metrics to session details in projects tab

### DIFF
--- a/core/project_manager.py
+++ b/core/project_manager.py
@@ -591,3 +591,31 @@ class ProjectManager:
 
         finally:
             conn.close()
+
+    def get_project_sessions(self, project_id: int):
+        """
+        Get all sessions assigned to a project with quality metrics.
+
+        Args:
+            project_id: Project ID
+
+        Returns:
+            List of tuples: (session_id, date_loc, filter, frame_count,
+                           approved_count, rejected_count, graded, avg_fwhm)
+        """
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        try:
+            cursor.execute('''
+                SELECT session_id, date_loc, filter, frame_count,
+                       approved_count, rejected_count, graded, avg_fwhm
+                FROM project_sessions
+                WHERE project_id = ?
+                ORDER BY date_loc DESC, filter
+            ''', (project_id,))
+
+            return cursor.fetchall()
+
+        finally:
+            conn.close()


### PR DESCRIPTION
Added a new "Assigned Sessions" section in the projects tab that displays all sessions assigned to a project with their quality metrics.

Features:
- New sessions table showing date, filter, frame count, approved count, average FWHM, and grading status
- Approved count displayed as fraction with percentage (e.g., 15/20 (75%))
- FWHM displayed in arcseconds with 2 decimal precision
- Grading status shows ✓ Graded (green) or ○ Ungraded (gray)
- Compact table layout with appropriate column widths
- Sessions ordered by date (descending) then filter

Implementation:
- Added get_project_sessions() method to ProjectManager to fetch session data from project_sessions table including quality metrics
- Added sessions_group QGroupBox to projects tab UI layout
- Added display_sessions() method to populate sessions table
- Updated show_project_details() to load and display sessions
- Updated clear_project_details() to hide sessions group

This provides visibility into the quality and grading status of all sessions assigned to a project, helping users track which sessions need grading and monitor overall imaging quality.

Files modified:
- core/project_manager.py: Added get_project_sessions() method
- ui/projects_tab.py: Added sessions display UI and logic