### PR TITLE
Fix column order restoration type error

### DIFF
--- a/ui/projects_tab.py
+++ b/ui/projects_tab.py
@@ -110,6 +110,8 @@ class ProjectsTab(QWidget):
         # Restore column order
         saved_order = self.settings.value('projects_table_col_order')
         if saved_order:
+            # Convert to integers (QSettings may return strings)
+            saved_order = [int(idx) for idx in saved_order]
             for visual_index, logical_index in enumerate(saved_order):
                 self.projects_table.horizontalHeader().moveSection(
                     self.projects_table.horizontalHeader().visualIndex(logical_index),
@@ -364,6 +366,8 @@ class ProjectsTab(QWidget):
         # Restore column order
         saved_order = self.settings.value('projects_goals_table_col_order')
         if saved_order:
+            # Convert to integers (QSettings may return strings)
+            saved_order = [int(idx) for idx in saved_order]
             for visual_index, logical_index in enumerate(saved_order):
                 goals_table.horizontalHeader().moveSection(
                     goals_table.horizontalHeader().visualIndex(logical_index),

--- a/ui/sessions_tab.py
+++ b/ui/sessions_tab.py
@@ -147,6 +147,8 @@ class SessionsTab(QWidget):
         # Restore column order
         saved_order = self.settings.value('sessions_tree_col_order')
         if saved_order:
+            # Convert to integers (QSettings may return strings)
+            saved_order = [int(idx) for idx in saved_order]
             for visual_index, logical_index in enumerate(saved_order):
                 self.sessions_tree.header().moveSection(
                     self.sessions_tree.header().visualIndex(logical_index),

--- a/ui/view_catalog_tab.py
+++ b/ui/view_catalog_tab.py
@@ -166,6 +166,8 @@ class ViewCatalogTab(QWidget):
         # Restore column order
         saved_order = self.settings.value('catalog_tree_col_order')
         if saved_order:
+            # Convert to integers (QSettings may return strings)
+            saved_order = [int(idx) for idx in saved_order]
             for visual_index, logical_index in enumerate(saved_order):
                 self.catalog_tree.header().moveSection(
                     self.catalog_tree.header().visualIndex(logical_index),


### PR DESCRIPTION
Fixed TypeError when restoring column order from QSettings. QSettings can return strings instead of integers, so we need to convert the saved order list to integers before using it.

Error:
TypeError: visualIndex(self, logicalIndex: int): argument 1 has unexpected type 'str'

Fix:
Added conversion to integers for all saved_order lists before restoring column order:
saved_order = [int(idx) for idx in saved_order]

Files fixed:
- ui/projects_tab.py: Both projects table and goals table
- ui/sessions_tab.py: Sessions tree
- ui/view_catalog_tab.py: Catalog tree