### PR TITLE
Disable direct editing in Projects table

### DIFF
--- a/ui/projects_tab.py
+++ b/ui/projects_tab.py
@@ -128,6 +128,7 @@ class ProjectsTab(QWidget):
         self.projects_table.setSelectionMode(
             QTableWidget.SelectionMode.SingleSelection
         )
+        self.projects_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self.projects_table.itemSelectionChanged.connect(self.on_project_selected)
 
         # Enable sorting by clicking column headers


### PR DESCRIPTION
Prevent users from editing project data directly in the table cells. All edits must now go through the Edit Project dialog.