### PR TITLE
Fix: Resolve issue #261

### DIFF
--- a/ui/projects_tab.py
+++ b/ui/projects_tab.py
@@ -207,7 +207,11 @@ class ProjectsTab(QWidget):
         # Connect splitter movement to save settings
         self.details_content_splitter.splitterMoved.connect(self.save_details_content_splitter_state)
 
-        details_layout.addWidget(self.details_content_splitter)
+        # Give the content splitter a stretch factor of 1 so the goals,
+        # master frames, and next steps windows expand to fill all the
+        # available vertical space. This pushes the action buttons below
+        # (see issue #261), giving these windows as much room as possible.
+        details_layout.addWidget(self.details_content_splitter, 1)
 
         # Action buttons - Data import and pre-processing workflow
         action_buttons = QHBoxLayout()
@@ -233,9 +237,12 @@ class ProjectsTab(QWidget):
         action_buttons.addWidget(self.mark_complete_btn)
 
         action_buttons.addStretch()
+
+        # Add the action buttons at the very bottom of the details panel.
+        # No trailing vertical stretch is added after them so the content
+        # splitter above keeps all the extra space (issue #261).
         details_layout.addLayout(action_buttons)
 
-        details_layout.addStretch()
         self.projects_splitter.addWidget(details_panel)
 
         # Set initial proportions: 70% for projects table, 30% for details


### PR DESCRIPTION
Resolves #261

## Changes
On the Projects Tab increase the amount of space available for the filters goals progress, next steps and master light frames windows by moving the buttons  (Import quality data, import master light frames, etc) lower

---
🤖 Auto-generated by Claude Code